### PR TITLE
Load ForwardDiff in MaximumLikelihood.jl

### DIFF
--- a/src/MaximumLikelihood.jl
+++ b/src/MaximumLikelihood.jl
@@ -5,6 +5,7 @@ using PDMats
 using ValidatedNumerics
 using StatsFuns
 using AutoAligns
+using ForwardDiff
 
 export estimate_ML
 


### PR DESCRIPTION
Hi Tamas,

I stumbled upon your wrapper for Maximum Likelihood and find it quite useful. However, at least in my installation, ForwardDiff needs to be loaded in the module in order to compute the Hessian.

Best, Benjamin